### PR TITLE
Remove reference to Shadow DOM pseudo-element

### DIFF
--- a/styles/underline-trailing-whitespace.less
+++ b/styles/underline-trailing-whitespace.less
@@ -2,8 +2,7 @@
 
 @underline-trailing-whitespace-color: @text-color-warning;
 
-atom-text-editor,
-atom-text-editor::shadow  {
+atom-text-editor {
 
   .trailing-whitespace {
     border-bottom: thin solid @underline-trailing-whitespace-color;


### PR DESCRIPTION
Shadow DOM was removed in Atom 1.13, deprecation-cop has been complaining since then.